### PR TITLE
Move server logs to /var/log/burp/burp.log

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -182,7 +182,7 @@ define burp::client (
     $_include = "${::burp::config_dir}/${name}-extra.conf"
     concat { "${::burp::config_dir}/${name}-extra.conf":
       ensure => $ensure,
-      mode   => 0600,
+      mode   => '0600',
     }
     concat::fragment { "burpclient_extra_header_${name}":
       target  => "${::burp::config_dir}/${name}-extra.conf",
@@ -194,18 +194,18 @@ define burp::client (
     ensure  => $_file_ensure,
     content => template('burp/burp.conf.erb'),
     require => Class['::burp::config'],
-    mode    => 0600,
+    mode    => '0600',
   }
 
   ## Prepare working dir
   file { $working_dir:
     ensure => $_directory_ensure,
-    mode   => 0750,
+    mode   => '0750',
     force  => true,
   } ->
   file { $_ca_dir:
     ensure => $_directory_ensure,
-    mode   => 0700,
+    mode   => '0700',
     force  => true,
   }
 

--- a/manifests/clientconfig.pp
+++ b/manifests/clientconfig.pp
@@ -49,7 +49,7 @@ define burp::clientconfig (
     ensure  => file,
     content => template('burp/burp-clientconfig.conf.erb'),
     require => Class['::burp::config'],
-    mode    => 0600,
+    mode    => '0600',
   }
   ensure_resource('file',"${::burp::server::clientconfig_dir}/${clientname}",$params)
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class burp::config {
 
   file { $::burp::config_dir:
     ensure  => directory,
-    mode    => 0750,
+    mode    => '0750',
     purge   => true,
     recurse => true,
     force   => true,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -51,7 +51,7 @@
 # [*manage_rsyslog*]
 #   Default: true
 #   Put a rsyslog config file under /etc/rsyslog.d/21-burp.conf to filter syslog
-#   messages from BURP backup server and put them into /var/log/burp.log.
+#   messages from BURP backup server and put them into /var/log/burp/burp.log.
 #
 # [*manage_service*]
 #   Default: true
@@ -275,11 +275,17 @@ class burp::server (
   if $manage_service {
     File[$config_file] ~> Service['burp']
     if $manage_rsyslog {
+      file { '/var/log/burp':
+        ensure => directory,
+        mode   => '0700',
+        owner  => 'syslog',
+        group  => 'adm',
+      }
       # Pitfall: This file resource does not notify rsyslog and so it only comes active
       # after manually reloading rsyslog
       file { '/etc/rsyslog.d/21-burp.conf':
         ensure  => file,
-        content => 'if $programname == \'burp\' then /var/log/burp.log',
+        content => 'if $programname == \'burp\' then /var/log/burp/burp.log',
         before  => Service['burp'],
       }
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -211,7 +211,7 @@ class burp::server (
   file { $config_file:
     ensure  => file,
     content => template('burp/burp.conf.erb'),
-    mode    => 0600,
+    mode    => '0600',
     owner   => $user,
     group   => $group,
     require => Class['::burp::config'],
@@ -222,7 +222,7 @@ class burp::server (
     file { $ca_config_file:
       ensure  => file,
       content => template('burp/CA.cnf.erb'),
-      mode    => 0600,
+      mode    => '0600',
       owner   => $user,
       group   => $group,
       require => Class['::burp::config'],
@@ -232,13 +232,13 @@ class burp::server (
   ## Prepare working directories
   file { $user_home:
     ensure => directory,
-    mode   => 0750,
+    mode   => '0750',
     owner  => $user,
     group  => $group,
   } ->
   file { $clientconfig_dir:
     ensure  => directory,
-    mode    => 0750,
+    mode    => '0750',
     purge   => true,
     recurse => true,
   }


### PR DESCRIPTION
In manage_rsyslog the burp.log file is located in /var/log/. This has issues with logrotate not rotating logs as the permissions on /var/log folder are correct as per logrotate requirements. 
to solve this and to make burp manage logs better we create a /var/log/burp folder and have rsyslog manage the /var/log/burp/burp.log file there