### PR TITLE
Fix/server perms

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -182,7 +182,7 @@ define burp::client (
     $_include = "${::burp::config_dir}/${name}-extra.conf"
     concat { "${::burp::config_dir}/${name}-extra.conf":
       ensure => $ensure,
-      mode   => '0600',
+      mode   => '0640',
     }
     concat::fragment { "burpclient_extra_header_${name}":
       target  => "${::burp::config_dir}/${name}-extra.conf",

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -194,7 +194,8 @@ define burp::client (
     ensure  => $_file_ensure,
     content => template('burp/burp.conf.erb'),
     require => Class['::burp::config'],
-    mode    => '0600',
+    mode    => '0640',
+    tag     => 'burp_config_file',
   }
 
   ## Prepare working dir
@@ -202,6 +203,7 @@ define burp::client (
     ensure => $_directory_ensure,
     mode   => '0750',
     force  => true,
+    tag    => 'burp_config_file',
   } ->
   file { $_ca_dir:
     ensure => $_directory_ensure,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class burp::config {
     purge   => true,
     recurse => true,
     force   => true,
+    tag     => 'burp_config_file',
   }
 
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -217,6 +217,11 @@ class burp::server (
     require => Class['::burp::config'],
   }
 
+  File <| tag == 'burp_config_file' |> {
+    owner => $user,
+    group => $group,
+  }
+
   ## Prepare CA
   if $ca_enabled {
     file { $ca_config_file:


### PR DESCRIPTION
To make burpui work with this module

 Burpui run as the burp group, read the configs in `/etc/burp/` to run `burp -a m` or `burp -a s` for status.