### PR TITLE
Allow local changes to config files and scripts

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -90,6 +90,10 @@
 #   Default: false
 #   Boolean stating whether to log to syslog or not.
 #
+# [*config_file_replace*]
+#   Default: true
+#   Boolean stating whether to overwrite local changes to config files.
+#
 # === Authors
 #
 # Tobias Brunner <tobias.brunner@vshn.ch>
@@ -119,6 +123,7 @@ define burp::client (
   $server = "backup.${::domain}",
   $password = fqdn_rand_string(10),
   $syslog = false,
+  $config_file_replace = true,
 ) {
 
   ## Input validation
@@ -137,6 +142,7 @@ define burp::client (
   validate_string($server)
   validate_string($password)
   validate_bool($syslog)
+  validate_bool($config_file_replace)
   if $ensure==present {
     $_directory_ensure = directory
     $_file_ensure = file
@@ -195,10 +201,11 @@ define burp::client (
   if $manage_extraconfig {
     $_include = "${::burp::config_dir}/${name}-extra.conf"
     concat { "${::burp::config_dir}/${name}-extra.conf":
-      ensure => $ensure,
-      mode   => $config_file_mode,
-      owner  => $user,
-      group  => $group,
+      ensure  => $ensure,
+      mode    => $config_file_mode,
+      owner   => $user,
+      group   => $group,
+      replace => $config_file_replace,
     }
     concat::fragment { "burpclient_extra_header_${name}":
       target  => "${::burp::config_dir}/${name}-extra.conf",
@@ -213,6 +220,7 @@ define burp::client (
     mode    => $config_file_mode,
     owner   => $user,
     group   => $group,
+    replace => $config_file_replace,
   }
 
   ## Prepare working dir

--- a/manifests/clientconfig.pp
+++ b/manifests/clientconfig.pp
@@ -52,6 +52,7 @@ define burp::clientconfig (
     mode    => $::burp::client::config_file_mode,
     owner   => $::burp::client::user,
     group   => $::burp::client::group,
+    replace => $::burp::server::config_file_replace,
   }
   ensure_resource('file',"${::burp::server::clientconfig_dir}/${clientname}",$params)
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -105,6 +105,14 @@
 #   Default: /var/lib/burp
 #   BURP backup server home and working directory.
 #
+# [*config_file_replace*]
+#   Default: true
+#   Boolean stating whether to overwrite local changes to config files.
+#
+# [*scripts_replace*]
+#   Default: true
+#   Boolean stating whether to overwrite local changes to scripts.
+#
 # === Authors
 #
 # Tobias Brunner <tobias.brunner@vshn.ch>
@@ -138,6 +146,8 @@ class burp::server (
   $ssl_dhfile = '/var/lib/burp/dhfile.pem',
   $ssl_key = '/var/lib/burp/ssl_cert-server.key',
   $user_home = '/var/lib/burp',
+  $config_file_replace = true,
+  $scripts_replace = true,
 ) {
 
   ## Input validation
@@ -162,7 +172,9 @@ class burp::server (
   validate_absolute_path($ssl_key)
   validate_string($user)
   validate_absolute_path($user_home)
-
+  validate_bool($config_file_replace)
+  validate_bool($scripts_replace)
+  
   include ::burp
 
   ## Default configuration parameters for BURP server
@@ -225,6 +237,7 @@ class burp::server (
     owner   => $user,
     group   => $group,
     require => Class['::burp::config'],
+    replace => $config_file_replace,
   }
 
   ## Prepare CA
@@ -236,6 +249,7 @@ class burp::server (
       owner   => $user,
       group   => $group,
       require => Class['::burp::config'],
+      replace => $config_file_replace,
     }
   }
 
@@ -257,24 +271,28 @@ class burp::server (
 
   ## Deliver original scripts
   file { '/usr/local/bin/burp_timer_script':
-    ensure => file,
-    mode   => '0755',
-    source => 'puppet:///modules/burp/timer_script',
+    ensure  => file,
+    mode    => '0755',
+    source  => 'puppet:///modules/burp/timer_script',
+    replace => $scripts_replace,
   }
   file { '/usr/local/bin/burp_summary_script':
-    ensure => file,
-    mode   => '0755',
-    source => 'puppet:///modules/burp/summary_script',
+    ensure  => file,
+    mode    => '0755',
+    source  => 'puppet:///modules/burp/summary_script',
+    replace => $scripts_replace,
   }
   file { '/usr/local/bin/burp_notify_script':
-    ensure => file,
-    mode   => '0755',
-    source => 'puppet:///modules/burp/notify_script',
+    ensure  => file,
+    mode    => '0755',
+    source  => 'puppet:///modules/burp/notify_script',
+    replace => $scripts_replace,
   }
   file { '/usr/local/bin/burp_ssl_extra_checks_script':
-    ensure => file,
-    mode   => '0755',
-    source => 'puppet:///modules/burp/ssl_extra_checks_script',
+    ensure  => file,
+    mode    => '0755',
+    source  => 'puppet:///modules/burp/ssl_extra_checks_script',
+    replace => $scripts_replace,
   }
 
   ## Instantiate clientconfigs


### PR DESCRIPTION
As we only manage one backup server and we also use etckeep and backup the etc directory it is more convenient to make changes to the server config file directly or via burp-ui. We still use the burp puppet module for initial setup and for introducing new clients to the server automatically. 
