### PR TITLE
Fix package install again 

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -167,6 +167,9 @@ define burp::client (
     $_cron_minute = $cron_minute
   }
 
+  # include base class
+  include ::burp
+
   ## Default configuration parameters for BURP client
   # parameters coming from a default BURP installation (most of them)
   $_ca_dir = "${working_dir}/ssl"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -60,10 +60,6 @@
 #   Default: true
 #   Collect `::burp::clientconfig` exported resources, filtered by `clientconfig_tag`.
 #
-# [*manage_package*]
-#   Default: true
-#   Enable or disable package installation.
-#
 # [*manage_rsyslog*]
 #   Default: true
 #   Put a rsyslog config file under /etc/rsyslog.d/21-burp.conf to filter syslog
@@ -76,14 +72,6 @@
 # [*manage_user*]
 #   Default: true
 #   Manage the BURP backup system service user.
-#
-# [*package_ensure*]
-#   Default: installed
-#   Can be used to choose exact package version to install.
-#
-# [*package_name*]
-#   Default: burp-server
-#   Manage the BURP backup system server package.
 #
 # [*service_enable*]
 #   Default: true
@@ -147,12 +135,9 @@ class burp::server (
   $config_file_mode = '0600',
   $homedir_file_mode = '0750',
   $manage_clientconfig = true,
-  $manage_package = true,
   $manage_rsyslog = true,
   $manage_service = true,
   $manage_user = true,
-  $package_ensure = 'installed',
-  $package_name = 'burp-server',
   $service_enable = true,
   $service_ensure = 'running',
   $service_name = 'burp',
@@ -189,7 +174,7 @@ class burp::server (
   validate_absolute_path($user_home)
   validate_bool($config_file_replace)
   validate_bool($scripts_replace)
-  
+
   include ::burp
 
   ## Default configuration parameters for BURP server
@@ -314,14 +299,6 @@ class burp::server (
   if $manage_clientconfig {
     ::Burp::Clientconfig <<| tag == $clientconfig_tag |>>
     create_resources('::burp::clientconfig',$clientconfigs)
-  }
-
-  ## Manage package if enabled
-
-  if $manage_package  {
-    package { $package_name:
-      ensure => $package_ensure,
-    }
   }
 
   ## Manage service if enabled


### PR DESCRIPTION
#12 actually broke the package handling a bit. this reverts the change and includes the base burp class also in client to make sure burp is installed and configured correctly if type burp::client is used directly. 