### PR TITLE
Set /etc/burp mode to 755

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,6 @@ class burp::config {
     ensure  => directory,
     mode    => '0755',
     purge   => true,
-    recurse => true,
     force   => true,
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class burp::config {
 
   file { $::burp::config_dir:
     ensure  => directory,
-    mode    => '0750',
+    mode    => '0755',
     purge   => true,
     recurse => true,
     force   => true,


### PR DESCRIPTION
When using
```
class { 'burp::server' :
  user => 'burp',
}
```

It is way too complicated to try to compare both `$::burp::server::user` and `$::burp::client::user` and try to generate a good ownership... So make it simple by having a mode `755` owned by root

Also, do not recurse as server.pp and client.pp both set their required mode