### PR TITLE
fix config dir permissions, extra config ordering

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -209,6 +209,8 @@ define burp::client (
       owner   => $user,
       group   => $group,
       replace => $config_file_replace,
+      require => Class['::burp::config'],
+
     }
     concat::fragment { "burpclient_extra_header_${name}":
       target  => "${::burp::config_dir}/${name}-extra.conf",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class burp::config {
 
   file { $::burp::config_dir:
     ensure  => directory,
-    mode    => '0750',
+    mode    => '0755',
     purge   => true,
     recurse => true,
     force   => true,


### PR DESCRIPTION
- fixes ordering issue for /etc/burp/burp-extra.conf on first puppet run
- fixes permissions for /etc/burp, since 2.0.46 burp runs as configured user (burp) again. directory was not readable for burp user. 

