### PR TITLE
Don't delete additional config files if config_file_replace is false

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -263,8 +263,8 @@ class burp::server (
   file { $clientconfig_dir:
     ensure  => directory,
     mode    => $config_file_mode,
-    purge   => true,
-    recurse => true,
+    purge   => $config_file_replace,
+    recurse => $config_file_replace,
     owner   => $user,
     group   => $group,
   }


### PR DESCRIPTION
When we are configured on not replacing config files we should also not delete new ones.