### PR TITLE
rodjek/logrotate is deprecated.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -63,7 +63,7 @@
 # [*manage_logrotate*]
 #   Default: true
 #   Rotate /var/log/burp/burp.log daily. Only active if manage_rsyslog is true as well.
-#   Requires rodjek/logrotate module.
+#   Requires puppet/logrotate module.
 #
 # [*manage_rsyslog*]
 #   Default: true

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
       "version_requirement": ">=1.0.0"
     },
     {
-      "name": "rodjek/logrotate",
+      "name": "puppet/logrotate",
       "version_requirement": ">=1.1.1"
     }
   ],


### PR DESCRIPTION
Hi,

rodjek/logrotate is deprecated and should be replace by puppet/logrotate. 